### PR TITLE
fix TypeError bug in `ensure_two_groups`

### DIFF
--- a/src/chlamytracker/stats_testing.py
+++ b/src/chlamytracker/stats_testing.py
@@ -23,7 +23,7 @@ def ensure_two_groups(data, groupby_variable):
     if num_groups != 2:
         msg = (
             "This function only supports statistical tests for two distinct groupings, but "
-            f"{len(num_groups)} were provided."
+            f"{num_groups} were provided."
         )
         raise ValueError(msg)
 


### PR DESCRIPTION
<!--
# TODO: Fill the name of the repo Arcadia-Science/<NAME> pull request

Many thanks for contributing to Arcadia-Science/<NAME>!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).
-->

Found and fixed bug in `ensure_two_groups` where `len` was operating on an integer.

## PR checklist

- [x] Describe the changes you've made.
