### PR TITLE
Fix duplicate read timelapse bug

### DIFF
--- a/src/chlamytracker/scripts/make_movies_of_pools.py
+++ b/src/chlamytracker/scripts/make_movies_of_pools.py
@@ -46,7 +46,6 @@ def make_napari_animation_for_timelapse(
         Frame rate for the animation.
     """
     # load timelapse and metadata
-    timelapse = nd2.imread(nd2_file)
     with nd2.ND2File(nd2_file) as nd2f:
         timelapse = nd2f.asarray()
         num_frames = nd2f.sizes["T"]

--- a/src/chlamytracker/scripts/make_movies_of_wells.py
+++ b/src/chlamytracker/scripts/make_movies_of_wells.py
@@ -46,7 +46,6 @@ def make_napari_animation_for_timelapse(
     """
     # load timelapse and metadata
     logger.info(f"Loading nd2 file {nd2_file}...")
-    timelapse = nd2.imread(nd2_file)
     with nd2.ND2File(nd2_file) as nd2f:
         timelapse = nd2f.asarray()
         num_frames = nd2f.sizes["T"]


### PR DESCRIPTION
<!--
# TODO: Fill the name of the repo Arcadia-Science/<NAME> pull request

Many thanks for contributing to Arcadia-Science/<NAME>!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).
-->

This PR fixes a bug in the scripts used to make movies in which the timelapse data was being read from disk twice.

## PR checklist

- [x] Describe the changes you've made.
