### PR TITLE
Fix `get_central_frames`

### DIFF
--- a/src/chlamytracker/stack_processing.py
+++ b/src/chlamytracker/stack_processing.py
@@ -1,3 +1,4 @@
+import warnings
 from multiprocessing import Pool
 
 import dask.array as da
@@ -27,10 +28,13 @@ def get_central_frames(stack, num_central_frames=100):
 
     if num_central_frames > num_total_frames:
         msg = (
-            f"Requested number of central frames ({num_central_frames}) greater "
-            f"than number of frames available ({num_total_frames})."
+            "Unable to crop central frames: Requested number of central "
+            f"frames ({num_central_frames}) greater than number of "
+            f"frames available ({num_total_frames})."
         )
-        raise ValueError(msg)
+        # raise ValueError(msg)
+        warnings.warn(msg, RuntimeWarning, stacklevel=1)
+        return stack.copy()
 
     # indices of central slices
     z1, z2 = (


### PR DESCRIPTION
This PR changes the behavior of `stack_processing.crop_central_frames`. Prior to this, function would raise a `ValueError` if more frames than existed in the stack were requested for cropping. Now just gives a warning and returns the whole stack (not cropped).

<!--
# TODO: Fill the name of the repo Arcadia-Science/<NAME> pull request

Many thanks for contributing to Arcadia-Science/<NAME>!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).
-->

## PR checklist

- [x] Describe the changes you've made.
- [x] If you've added new functionality, make sure that the documentation is updated accordingly.
